### PR TITLE
fix propFile creation

### DIFF
--- a/src/main/java/me/grax/jbytemod/res/Options.java
+++ b/src/main/java/me/grax/jbytemod/res/Options.java
@@ -86,7 +86,7 @@ public class Options {
     new Thread(() -> {
       try {
         if(!propFile.exists()) {
-          propFile.mkdirs();
+          propFile.getParentFile().mkdirs();
           propFile.createNewFile();
           JByteMod.LOGGER.log("Prop file doesn't exist, creating.");
         }


### PR DESCRIPTION
Fixes crash on startup when propFile doesn't exist. File.mkdirs() creates directories up to and INCLUDING the current object. So a directory named jbytemod.cfg is created.