### PR TITLE
Fix "jump_to_label", was German not english

### DIFF
--- a/src/main/resources/locale/en.xml
+++ b/src/main/resources/locale/en.xml
@@ -86,7 +86,7 @@
    <string name="memory_warning">Memory warning at loading</string>
    <string name="memory_full">Failed loading file: Memory full</string>
    <string name="analyze_errors">Display mistakes</string>
-   <string name="jump_to_label">Zum Label springen</string>
+   <string name="jump_to_label">Jump to label</string>
    <string name="search_ldc">Search LDC</string>
    <string name="search_field">Search Field reference</string>
    <string name="search_method">Search Method reference</string>


### PR DESCRIPTION
jump_to_label on default english xml file was german, needs fixing.