### PR TITLE
Allow editing of "itf" field of MethodInsnNode

### DIFF
--- a/src/main/java/me/grax/jbytemod/ui/dialogue/ClassDialogue.java
+++ b/src/main/java/me/grax/jbytemod/ui/dialogue/ClassDialogue.java
@@ -280,7 +280,7 @@ public class ClassDialogue {
         }
         rightInput.add(wrap(f, edit));
       }
-      leftText.add(new JLabel(formatText(f.getName()) + ": "));
+      leftText.add(new JLabel(getFieldName(f.getName(), f.getType()) + ": "));
     }
 
     mainPanel.add(leftText, BorderLayout.WEST);
@@ -313,6 +313,10 @@ public class ClassDialogue {
 
   protected boolean isModifiedSpecial(String name, Class<?> type) {
     return false;
+  }
+
+  protected String getFieldName(String name, Class<?> type) {
+    return formatText(name);
   }
 
   protected Component wrap(Field f, Component component) {

--- a/src/main/java/me/grax/jbytemod/ui/dialogue/InsnEditDialogue.java
+++ b/src/main/java/me/grax/jbytemod/ui/dialogue/InsnEditDialogue.java
@@ -268,7 +268,7 @@ public class InsnEditDialogue extends ClassDialogue {
 
   @Override
   protected boolean ignore(String name) {
-    return name.equals("itf") || name.toLowerCase().contains("annotation") || name.equals("visited") || name.equals("tryCatchBlocks")
+    return name.toLowerCase().contains("annotation") || name.equals("visited") || name.equals("tryCatchBlocks")
         || name.equals("localVariables") || name.equals("instructions") || name.equals("preLoad") || name.equals("attrs") || name.equals("extraBytes")
         || name.equals("methods") || name.equals("fields") || name.equals("local") || name.equals("stack") || name.equals("hash")
         || name.equals("parameters") || name.equals("exceptions") || name.equals("innerClasses") || name.equals("module");
@@ -541,6 +541,14 @@ public class InsnEditDialogue extends ClassDialogue {
       return jtf;
     }
     return null;
+  }
+
+  @Override
+  protected String getFieldName(String name, Class<?> type) {
+    if("itf".equals(name)) {
+      return "Interface";
+    }
+    return super.getFieldName(name, type);
   }
 
   public static boolean canEdit(AbstractInsnNode ain) {


### PR DESCRIPTION
This addresses #69 

Additionally, with Java 8, "invokestatic" may also use an InterfaceMethodref constant. Therefore I have chosen the approach of exposing a checkbox rather than automatically setting the field if the opcode name is "invokeinterface".

![image](https://user-images.githubusercontent.com/8008710/50154239-c7af1180-0296-11e9-88a8-46c9b497ea00.png)


Before (output of `javap -c`):

```
...
      12: aload_1
      13: invokeinterface #177,  1          // Method net/minecraft/block/state/IBlockState.func_177230_c:()Lnet/minecraft/block/Block;
      18: instanceof    #179                // class betterwithmods/common/blocks/mechanical/BlockCookingPot
...
```

Constant #177 for instruction 13 is a `MethodRef`, as seen in `// Method ...`. This is an illegal scenario, as `invokeinterface` requires an `InterfaceMethodref`.

After:

```
...
      12: aload_1
      13: invokeinterface #177,  1          // InterfaceMethod net/minecraft/block/state/IBlockState.func_177230_c:()Lnet/minecraft/block/Block;
      18: instanceof    #179                // class betterwithmods/common/blocks/mechanical/BlockCookingPot
...
```

All better!